### PR TITLE
Updating multiple dependencies to take care of the Spring vulnerability.

### DIFF
--- a/marklogic-junit5/build.gradle
+++ b/marklogic-junit5/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 dependencies {
   api project(":marklogic-unit-test-client")
-  api "com.marklogic:ml-javaclient-util:4.3.0"
+  api "com.marklogic:ml-javaclient-util:4.3.1"
   api "org.jdom:jdom2:2.0.6"
   api "org.junit.jupiter:junit-jupiter:5.7.2"
-  api "org.springframework:spring-context:5.3.9"
-  api "org.springframework:spring-test:5.3.9"
+  api "org.springframework:spring-context:5.3.18"
+  api "org.springframework:spring-test:5.3.18"
   api "com.fasterxml.jackson.core:jackson-databind:2.11.1"
   api "org.slf4j:slf4j-api:1.7.31"
 

--- a/marklogic-junit5/examples/simple-ml-gradle/build.gradle
+++ b/marklogic-junit5/examples/simple-ml-gradle/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
   mlBundle "com.marklogic:marklogic-unit-test-modules:1.1.0"
 
-	api "com.marklogic:marklogic-client-api:5.5.0"
+	api "com.marklogic:marklogic-client-api:5.5.3"
 
 	testImplementation "com.marklogic:marklogic-junit5:1.1.0"
 

--- a/marklogic-junit5/pom.xml
+++ b/marklogic-junit5/pom.xml
@@ -46,7 +46,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-javaclient-util</artifactId>
-      <version>4.3.0</version>
+      <version>4.3.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -64,13 +64,13 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.9</version>
+      <version>5.3.18</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.3.9</version>
+      <version>5.3.18</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/marklogic-unit-test-client/build.gradle
+++ b/marklogic-unit-test-client/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-	api "com.marklogic:marklogic-client-api:5.5.0"
+	api "com.marklogic:marklogic-client-api:5.5.3"
   implementation "org.slf4j:slf4j-api:1.7.31"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"

--- a/marklogic-unit-test-client/pom.xml
+++ b/marklogic-unit-test-client/pom.xml
@@ -40,7 +40,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-client-api</artifactId>
-      <version>5.5.0</version>
+      <version>5.5.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- org.springframework:spring-context:5.3.9->5.3.18
- org.springframework:spring-test:5.3.9->5.3.18
- ml-javaclient-util:4.3.0->4.3.1
- marklogic-client-api:5.5.0->5.5.3